### PR TITLE
Add sign-in guard and hide signup link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Home</title>
+</head>
+<body>
+    <h1>Welcome</h1>
+    <nav>
+        <ul>
+            <li id="signupLink"><a href="/signup.html">Sign Up</a></li>
+            <li><a href="/signin.html">Sign In</a></li>
+            <li><a href="/user.html">User Management</a></li>
+        </ul>
+    </nav>
+    <script>
+        const token = localStorage.getItem('token');
+        if (token) {
+            const signup = document.getElementById('signupLink');
+            if (signup) signup.remove();
+        }
+    </script>
+</body>
+</html>

--- a/public/signin.html
+++ b/public/signin.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Sign In</title>
+</head>
+<body>
+    <h1>Sign In</h1>
+    <form id="signinForm">
+        <label>User ID <input type="text" name="userId" required></label><br>
+        <label>Passcode <input type="password" name="passcode" required></label><br>
+        <button type="submit">Submit</button>
+    </form>
+    <p id="message"></p>
+    <script>
+    const form = document.getElementById('signinForm');
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const formData = new FormData(form);
+        const data = Object.fromEntries(formData.entries());
+        const res = await fetch('/signin', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(data)
+        });
+        const msg = document.getElementById('message');
+        if (res.ok) {
+            const j = await res.json();
+            localStorage.setItem('token', j.token);
+            msg.textContent = 'Signed in!';
+        } else {
+            const err = await res.json();
+            msg.textContent = err.error || 'Error';
+        }
+    });
+    </script>
+</body>
+</html>

--- a/public/signup.html
+++ b/public/signup.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Sign Up</title>
+</head>
+<body>
+    <h1>Sign Up</h1>
+    <form id="signupForm">
+        <label>User ID <input type="text" name="userId" maxlength="10" required></label><br>
+        <label>Passcode <input type="password" name="passcode" pattern="\d{4}" required></label><br>
+        <label>Username <input type="text" name="username" maxlength="20" required></label><br>
+        <label>Profile <input type="text" name="profile"></label><br>
+        <button type="submit">Submit</button>
+    </form>
+    <p id="message"></p>
+    <script>
+    const token = localStorage.getItem('token');
+    if (token) {
+        // Already signed in, don't allow sign up page
+        window.location.href = '/';
+    } else {
+        const form = document.getElementById('signupForm');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const formData = new FormData(form);
+            const data = Object.fromEntries(formData.entries());
+            const res = await fetch('/signup', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(data)
+            });
+            const msg = document.getElementById('message');
+            if (res.ok) {
+                msg.textContent = 'Signed up!';
+            } else {
+                const err = await res.json();
+                msg.textContent = err.error || 'Error';
+            }
+        });
+    }
+    </script>
+</body>
+</html>

--- a/public/user.html
+++ b/public/user.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>User Management</title>
+</head>
+<body>
+    <h1>User Management</h1>
+    <div id="userInfo"></div>
+    <form id="updateForm">
+        <label>Username <input type="text" name="username" maxlength="20"></label><br>
+        <label>Profile <input type="text" name="profile"></label><br>
+        <label>Passcode <input type="password" name="passcode" pattern="\d{4}"></label><br>
+        <button type="submit">Update</button>
+    </form>
+    <p id="message"></p>
+    <script>
+    const token = localStorage.getItem('token');
+    if (!token) {
+        // Redirect unauthenticated users to sign-in page
+        window.location.href = '/signin.html';
+    } else {
+        fetch('/me', {headers: {'Authorization': 'Bearer ' + token}})
+            .then(res => res.json())
+            .then(user => {
+                const div = document.getElementById('userInfo');
+                div.textContent = `User ID: ${user.userId}, Username: ${user.username}`;
+            });
+        const form = document.getElementById('updateForm');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const data = Object.fromEntries(new FormData(form).entries());
+            const res = await fetch('/me', {
+                method: 'PUT',
+                headers: {'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token},
+                body: JSON.stringify(data)
+            });
+            const msg = document.getElementById('message');
+            if (res.ok) {
+                msg.textContent = 'Updated';
+            } else {
+                const err = await res.json();
+                msg.textContent = err.error || 'Error';
+            }
+        });
+    }
+    </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -7,6 +7,23 @@ const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+app.get('/signup', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'signup.html'));
+});
+
+app.get('/signin', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'signin.html'));
+});
+
+app.get('/user', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'user.html'));
+});
 
 // Simple in-memory session store
 const sessions = new Map();


### PR DESCRIPTION
## Summary
- hide Sign Up link once authenticated
- block access to signup page when already signed in
- require sign-in before accessing user management

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840281860b0832aaafe22a89f7652f9