### PR TITLE
Prevent signup when already logged in

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The server provides several routes:
 
 - `GET /items` – fetch all items from the database.
 - `POST /items` – add a new item by providing a JSON body with a `name` field.
-- `POST /signup` – create a new user. Requires `userId`, `passcode`, `username`, and optional `profile` in the request body.
+- `POST /signup` – create a new user. Requires `userId`, `passcode`, `username`, and optional `profile` in the request body. The request is rejected if a valid `Authorization` token is provided (i.e. when already signed in).
 - `POST /signin` – sign in with `userId` and `passcode`. Returns an authentication token.
 - `POST /logout` – invalidate the current session. Requires `Authorization: Bearer <token>` header.
 - `GET /me` – retrieve the currently signed-in user's info.

--- a/server.js
+++ b/server.js
@@ -98,6 +98,14 @@ function auth(req, res, next) {
 }
 
 app.post('/signup', (req, res) => {
+  const authHeader = req.headers['authorization'];
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.slice(7);
+    if (sessions.has(token)) {
+      return res.status(400).json({ error: 'Already signed in' });
+    }
+  }
+
   const { userId, passcode, username, profile } = req.body;
   if (!userId || userId.length > 10) {
     return res.status(400).json({ error: 'Invalid userId' });


### PR DESCRIPTION
## Summary
- block POST `/signup` when a valid session token is provided
- document new restriction in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840527c3c8c832a8b05602ae9a4b00e