### PR TITLE
Display existing data on user screen

### DIFF
--- a/public/user.html
+++ b/public/user.html
@@ -20,13 +20,16 @@
         // Redirect unauthenticated users to sign-in page
         window.location.href = '/signin.html';
     } else {
+        const form = document.getElementById('updateForm');
         fetch('/me', {headers: {'Authorization': 'Bearer ' + token}})
             .then(res => res.json())
             .then(user => {
                 const div = document.getElementById('userInfo');
-                div.textContent = `User ID: ${user.userId}, Username: ${user.username}`;
+                div.textContent = `User ID: ${user.userId}`;
+                if (user.username) form.username.value = user.username;
+                if (user.profile) form.profile.value = user.profile;
             });
-        const form = document.getElementById('updateForm');
+        
         form.addEventListener('submit', async (e) => {
             e.preventDefault();
             const data = Object.fromEntries(new FormData(form).entries());


### PR DESCRIPTION
## Summary
- prefill the user management page with the signed-in user's data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68418b55d988832a9768e15334c4bf62